### PR TITLE
設定ファイルによるオプション指定に対応

### DIFF
--- a/.ai-agent/tasks/20260221-config-file-support/README.md
+++ b/.ai-agent/tasks/20260221-config-file-support/README.md
@@ -1,0 +1,35 @@
+# config-file-support
+
+## 概要
+
+オプションを設定ファイルで受け取れるようにする。
+
+## 背景
+
+現在、cc-voice-reporter のオプションは CLI 引数（`--include`, `--exclude`）のみで設定できる。
+設定ファイルに対応することで、以下の利点が得られる:
+
+- 毎回 CLI 引数を指定する必要がなくなる
+- Speaker の maxLength、debounceMs などの詳細オプションも設定可能になる
+- フェーズ 4/5 の機能拡充（多言語対応、音声設定）の基盤になる
+
+## 現在の設定可能項目
+
+- `WatcherOptions`: `projectsDir`, `filter.include`, `filter.exclude`
+- `SpeakerOptions`: `maxLength`, `truncationSeparator`
+- `DaemonOptions`: `debounceMs`
+
+## 設計上の判断ポイント
+
+- 設定ファイルのフォーマット（JSON / TOML / YAML など）
+- 設定ファイルの配置場所（XDG Base Directory 準拠、~/.config/ など）
+- CLI 引数と設定ファイルの優先順位
+- 設定ファイルが存在しない場合のデフォルト動作
+
+## ステータス
+
+- [x] タスク作成
+- [ ] 設計
+- [ ] 実装
+- [ ] レビュー
+- [ ] 完了

--- a/.ai-agent/tasks/20260221-config-file-support/design.md
+++ b/.ai-agent/tasks/20260221-config-file-support/design.md
@@ -1,0 +1,288 @@
+# 設定ファイル対応 設計ドキュメント
+
+## Context
+
+cc-voice-reporter は現在 CLI 引数（`--include`, `--exclude`）のみでオプションを受け取っている。設定ファイルに対応することで、毎回の引数指定が不要になり、`maxLength`・`debounceMs` 等の詳細オプションも永続的に設定可能になる。
+
+## 1. 設定ファイルのフォーマットと配置場所
+
+### フォーマット: JSON
+
+- zod が既に依存にあり、`JSON.parse` + zod バリデーションで完結
+- 追加の依存パッケージ不要
+- TypeScript との親和性が高い
+
+### 配置場所: XDG Base Directory 準拠
+
+```
+$XDG_CONFIG_HOME/cc-voice-reporter/config.json
+```
+
+デフォルト（`$XDG_CONFIG_HOME` 未設定時）:
+
+```
+~/.config/cc-voice-reporter/config.json
+```
+
+**理由**: macOS の CLI ツールでは XDG 準拠が広く採用されている（git, npm 等）。`~/.cc-voice-reporter.json` のようなホームディレクトリ直下のドットファイルよりも整理された配置になる。
+
+### CLI 引数 `--config` による上書き
+
+```
+cc-voice-reporter --config ./my-config.json
+```
+
+任意の設定ファイルパスを指定可能にする。
+
+## 2. 設定スキーマ（zod 定義）
+
+`src/config.ts` に定義:
+
+```typescript
+import { z } from "zod";
+
+export const ConfigSchema = z.object({
+  /** 監視対象プロジェクトのフィルタリング */
+  filter: z.object({
+    include: z.array(z.string()).optional(),
+    exclude: z.array(z.string()).optional(),
+  }).optional(),
+
+  /** 監視ディレクトリ（通常変更不要） */
+  projectsDir: z.string().optional(),
+
+  /** デバウンス間隔（ms） */
+  debounceMs: z.number().int().positive().optional(),
+
+  /** 音声出力設定 */
+  speaker: z.object({
+    /** 最大文字数（これを超えると中間省略） */
+    maxLength: z.number().int().positive().optional(),
+    /** 省略時の区切り文字 */
+    truncationSeparator: z.string().optional(),
+  }).optional(),
+});
+
+export type Config = z.infer<typeof ConfigSchema>;
+```
+
+### 設定ファイル例
+
+```json
+{
+  "filter": {
+    "include": ["my-project", "other-project"],
+    "exclude": ["/Users/me/Workspace/tmp-project"]
+  },
+  "debounceMs": 300,
+  "speaker": {
+    "maxLength": 150,
+    "truncationSeparator": "、省略、"
+  }
+}
+```
+
+### スキーマ設計のポイント
+
+- **全フィールド optional**: 設定ファイルには変更したい項目だけ書けばよい
+- **フラット寄りの構造**: `watcher.filter` ではなく `filter` をトップレベルに配置。ユーザーが最も使う設定（filter）へのアクセスを簡潔にする
+- **テスト専用オプション（`speakFn`, `executor`, `resolveProjectName`）は除外**: 設定ファイルに含めない
+- **`projectsDir` はトップレベル**: 上級者向けだが、テスト等で必要になる場合がある
+
+## 3. CLI 引数と設定ファイルの優先順位
+
+```
+CLI 引数 > 設定ファイル > デフォルト値
+```
+
+### マージルール
+
+- CLI 引数で指定された値は、設定ファイルの同名の値を上書きする
+- 設定ファイルに存在しないフィールドはデフォルト値が使われる
+- `filter.include` / `filter.exclude` は配列単位で上書き（マージではない）
+  - CLI で `--include a` を指定した場合、設定ファイルの `filter.include: ["b", "c"]` は無視される
+
+### CLI 引数の拡張
+
+現在の引数:
+- `--include <pattern>` (multiple)
+- `--exclude <pattern>` (multiple)
+
+追加する引数:
+- `--config <path>` — 設定ファイルパスの明示指定
+
+**追加しない引数**: `--debounceMs`, `--maxLength` 等の詳細オプションは CLI 引数に追加しない。これらは使用頻度が低く、設定ファイルでの指定で十分。CLI 引数を増やしすぎると `--help` が煩雑になる。
+
+## 4. 設定ファイルが存在しない場合のデフォルト動作
+
+- **設定ファイルなし → エラーにしない**: 現在と同じデフォルト値で動作する
+- **`--config` で指定したファイルが存在しない → エラー**: 明示指定は存在を期待しているため
+- **設定ファイルの JSON パースエラー → エラー**: ファイルが存在するが不正な場合は起動しない
+- **設定ファイルの zod バリデーションエラー → エラー**: 不明なキーや型不正は起動時にわかりやすくエラーメッセージを表示
+
+### デフォルト値一覧
+
+| 設定項目 | デフォルト値 | 由来 |
+|---------|------------|------|
+| `filter.include` | `undefined`（全プロジェクト） | watcher.ts |
+| `filter.exclude` | `undefined`（除外なし） | watcher.ts |
+| `projectsDir` | `~/.claude/projects` | watcher.ts `DEFAULT_PROJECTS_DIR` |
+| `debounceMs` | `500` | daemon.ts |
+| `speaker.maxLength` | `100` | speaker.ts |
+| `speaker.truncationSeparator` | `"、中略、"` | speaker.ts |
+
+## 5. 実装方針
+
+### ファイル構成
+
+- **新規**: `src/config.ts` — 設定スキーマ定義、設定ファイル読み込み、CLI 引数とのマージ
+- **変更**: `src/cli.ts` — `--config` 引数の追加、設定ファイル読み込みの呼び出し、DaemonOptions の組み立て
+
+### 関数インターフェース
+
+#### `loadConfig(configPath?: string): Promise<Config>`
+
+設定ファイルを読み込み・バリデーションする。
+
+- `configPath` 指定時 → そのファイルを読み込み（存在しなければエラー）
+- 未指定時 → XDG デフォルトパスを探索（存在しなければ空 `{}` を返す）
+- JSON パースエラー・zod バリデーションエラー → エラーをスロー
+
+```typescript
+export async function loadConfig(configPath?: string): Promise<Config> {
+  const filePath = configPath ?? getDefaultConfigPath();
+
+  let content: string;
+  try {
+    content = await fs.promises.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (isNodeError(err) && err.code === "ENOENT") {
+      if (configPath !== undefined) {
+        throw new Error(`Config file not found: ${filePath}`);
+      }
+      return {};
+    }
+    throw err;
+  }
+
+  const json: unknown = JSON.parse(content);
+  const result = ConfigSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(
+      `Invalid config file ${filePath}: ${result.error.message}`
+    );
+  }
+  return result.data;
+}
+```
+
+#### `getDefaultConfigPath(): string`
+
+XDG 準拠のデフォルト設定ファイルパスを返す。
+
+```typescript
+function getDefaultConfigPath(): string {
+  const xdgConfigHome = process.env["XDG_CONFIG_HOME"]
+    ?? path.join(os.homedir(), ".config");
+  return path.join(xdgConfigHome, "cc-voice-reporter", "config.json");
+}
+```
+
+#### `resolveOptions(config, cliArgs): DaemonOptions`
+
+設定ファイルと CLI 引数をマージして DaemonOptions を生成する。
+
+```typescript
+export function resolveOptions(
+  config: Config,
+  cliArgs: { include?: string[]; exclude?: string[] },
+): DaemonOptions {
+  const filter: ProjectFilter = {};
+  const includeSource = cliArgs.include ?? config.filter?.include;
+  const excludeSource = cliArgs.exclude ?? config.filter?.exclude;
+  if (includeSource) filter.include = includeSource;
+  if (excludeSource) filter.exclude = excludeSource;
+
+  return {
+    watcher: {
+      projectsDir: config.projectsDir,
+      filter,
+    },
+    speaker: config.speaker,
+    debounceMs: config.debounceMs,
+  };
+}
+```
+
+### cli.ts の変更イメージ
+
+```typescript
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      include: { type: "string", multiple: true },
+      exclude: { type: "string", multiple: true },
+      config: { type: "string" },
+    },
+  });
+
+  const config = await loadConfig(values.config);
+  const options = resolveOptions(config, {
+    include: values.include,
+    exclude: values.exclude,
+  });
+
+  const daemon = new Daemon(options);
+  // ... 以降は既存コードと同じ
+}
+```
+
+## 6. ユーザビリティ要件・受け入れ基準
+
+1. **設定ファイルなしで現在と同じ動作**: 既存ユーザーに影響なし
+2. **設定ファイルの JSON エラー・バリデーションエラー時にわかりやすいメッセージ**: ファイルパスと具体的なエラー内容を表示
+3. **`--config` で任意のパスを指定可能**: テストや複数設定の切り替えに対応
+4. **部分的な設定ファイルが有効**: 全フィールドを書く必要がない（変更したい項目のみ）
+5. **CLI 引数が設定ファイルより優先される**: 一時的な上書きが可能
+
+## 7. 品質指標
+
+### テストカバレッジ
+
+- `loadConfig()` のテスト:
+  - ファイルなし（デフォルトパス）→ 空設定を返す
+  - ファイルなし（`--config` 指定）→ エラー
+  - 有効な JSON → パース成功
+  - 不正な JSON → パースエラー
+  - スキーマ不一致 → バリデーションエラー
+  - 部分設定（一部フィールドのみ）→ 成功
+- `resolveOptions()` のテスト:
+  - 設定ファイルのみ → 設定値が反映
+  - CLI 引数のみ → CLI 値が反映
+  - 両方指定 → CLI が優先
+  - 両方なし → デフォルト値
+- `getDefaultConfigPath()` のテスト:
+  - `XDG_CONFIG_HOME` 設定あり → そのパスを使用
+  - `XDG_CONFIG_HOME` 未設定 → `~/.config/...` を使用
+
+### 既存テストへの影響
+
+- 既存テストは変更不要（DaemonOptions のインターフェースは変更しない）
+
+### コード品質
+
+- 新規コードは既存の lint / type-check をパス
+- エラーメッセージは日本語（既存の stderr メッセージに合わせる）
+
+## 8. 検証方法
+
+1. `npm run build` — ビルド成功
+2. `npm test` — 全テスト通過（新規テスト含む）
+3. `npm run lint` — リントエラーなし
+4. 手動検証:
+   - 設定ファイルなしで起動 → 現在と同じ動作
+   - `~/.config/cc-voice-reporter/config.json` に設定を書いて起動 → 反映される
+   - `--config ./test-config.json` で起動 → 指定ファイルの設定が反映
+   - 不正な JSON で起動 → わかりやすいエラーメッセージ
+   - CLI 引数 `--include` と設定ファイルの `filter.include` を両方指定 → CLI が優先

--- a/.ai-agent/tasks/20260221-config-file-support/review.md
+++ b/.ai-agent/tasks/20260221-config-file-support/review.md
@@ -1,0 +1,51 @@
+# コードレビュー結果: 設定ファイル対応
+
+## 総合評価: LGTM (Approve)
+
+**Critical な問題はありません。**
+
+ビルド・テスト (178 passed)・リントすべて通過。
+
+---
+
+## レビュー対象
+
+1. `src/config.ts`（新規: 設定スキーマ、loadConfig、resolveOptions）
+2. `src/config.test.ts`（新規: テスト 22件）
+3. `src/cli.ts`（変更: --config 引数追加、loadConfig + resolveOptions 呼び出し）
+
+## 良い点
+
+1. **設計書への忠実な実装**: `loadConfig`, `getDefaultConfigPath`, `resolveOptions` すべて設計書通りのインターフェースと動作
+2. **`.strict()` の使用**: ConfigSchema で unknown keys を拒否しており、ユーザーの typo を検出できる（設計書には明示されていないが良い判断）
+3. **JSON パースエラーのハンドリング**: `JSON.parse` を try-catch で囲み、ユーザーフレンドリーなエラーメッセージを表示（設計書のサンプルコードでは `JSON.parse` が裸で呼ばれていたのを改善）
+4. **型安全性**: `DaemonOptions`, `WatcherOptions`, `SpeakerOptions` との型互換性が正しく保たれている。`Config` の `speaker` フィールドは `SpeakerOptions` のサブセット（`executor` を除外）で正しい
+5. **テストカバレッジ**: 設計書の品質指標に記載された全テストケースがカバーされている
+6. **cli.ts の変更が最小限**: 既存の shutdown ロジック等に影響なし
+
+## 軽微な指摘（修正不要、情報共有）
+
+1. **エラーメッセージの言語**: 設計書の品質指標に「エラーメッセージは日本語」とあるが、実装は英語。ただし既存の cli.ts のメッセージ（"shutting down...", "daemon started", "fatal:"）もすべて英語なので、**実装がコードベースと一貫しており正しい**。設計書側の記述が不正確
+2. **resolveOptions の include/exclude 独立性**: CLI で `--include` のみ指定した場合、config の `exclude` はそのまま残る動作。テスト (line 219-227) で明示的に検証されており、設計書の「配列単位で上書き」の仕様通り
+
+## セキュリティ
+
+- `--config` でユーザー指定パスを `fs.promises.readFile` で読み込む: CLI ツールとして適切（ユーザー自身がパスを指定）
+- `JSON.parse` は安全（コード実行リスクなし）
+- zod `.strict()` で未知キーを拒否: 意図しないデータの混入を防止
+
+## 設計書の受け入れ基準チェック
+
+1. **設定ファイルなしで現在と同じ動作**: OK（`loadConfig()` → `{}` → resolveOptions で全 undefined）
+2. **JSON エラー・バリデーションエラー時にわかりやすいメッセージ**: OK
+3. **`--config` で任意のパスを指定可能**: OK
+4. **部分的な設定ファイルが有効**: OK（全フィールド optional + テスト検証済み）
+5. **CLI 引数が設定ファイルより優先**: OK（テスト検証済み）
+
+## 検証結果
+
+| 検証項目 | 結果 |
+|---------|------|
+| `npm run build` | Pass |
+| `npm test` | Pass (178 tests) |
+| `npm run lint` | Pass |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
 
 import { parseArgs } from "node:util";
 import { Daemon } from "./daemon.js";
+import { loadConfig, resolveOptions } from "./config.js";
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
@@ -13,17 +14,17 @@ async function main(): Promise<void> {
     options: {
       include: { type: "string", multiple: true },
       exclude: { type: "string", multiple: true },
+      config: { type: "string" },
     },
   });
 
-  const daemon = new Daemon({
-    watcher: {
-      filter: {
-        include: values.include,
-        exclude: values.exclude,
-      },
-    },
+  const config = await loadConfig(values.config);
+  const options = resolveOptions(config, {
+    include: values.include,
+    exclude: values.exclude,
   });
+
+  const daemon = new Daemon(options);
 
   const shutdown = (): void => {
     process.stderr.write("[cc-voice-reporter] shutting down...\n");

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,263 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ConfigSchema,
+  getDefaultConfigPath,
+  loadConfig,
+  resolveOptions,
+} from "./config.js";
+
+describe("ConfigSchema", () => {
+  it("accepts an empty object", () => {
+    const result = ConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a full config", () => {
+    const result = ConfigSchema.safeParse({
+      filter: {
+        include: ["project-a"],
+        exclude: ["/absolute/path"],
+      },
+      projectsDir: "/custom/projects",
+      debounceMs: 300,
+      speaker: {
+        maxLength: 150,
+        truncationSeparator: "...",
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a partial config", () => {
+    const result = ConfigSchema.safeParse({
+      debounceMs: 1000,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ debounceMs: 1000 });
+  });
+
+  it("rejects unknown keys", () => {
+    const result = ConfigSchema.safeParse({
+      unknownKey: "value",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid debounceMs (non-positive)", () => {
+    const result = ConfigSchema.safeParse({
+      debounceMs: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid debounceMs (non-integer)", () => {
+    const result = ConfigSchema.safeParse({
+      debounceMs: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid speaker.maxLength (non-positive)", () => {
+    const result = ConfigSchema.safeParse({
+      speaker: { maxLength: 0 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("getDefaultConfigPath", () => {
+  const originalEnv = process.env["XDG_CONFIG_HOME"];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["XDG_CONFIG_HOME"];
+    } else {
+      process.env["XDG_CONFIG_HOME"] = originalEnv;
+    }
+  });
+
+  it("uses XDG_CONFIG_HOME when set", () => {
+    process.env["XDG_CONFIG_HOME"] = "/custom/config";
+    expect(getDefaultConfigPath()).toBe(
+      "/custom/config/cc-voice-reporter/config.json",
+    );
+  });
+
+  it("falls back to ~/.config when XDG_CONFIG_HOME is not set", () => {
+    delete process.env["XDG_CONFIG_HOME"];
+    const expected = path.join(
+      os.homedir(),
+      ".config",
+      "cc-voice-reporter",
+      "config.json",
+    );
+    expect(getDefaultConfigPath()).toBe(expected);
+  });
+});
+
+describe("loadConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "cc-voice-reporter-config-test-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty config when default path does not exist", async () => {
+    // loadConfig with no arg uses getDefaultConfigPath().
+    // Override XDG to point to a non-existent dir.
+    const originalEnv = process.env["XDG_CONFIG_HOME"];
+    process.env["XDG_CONFIG_HOME"] = path.join(tmpDir, "nonexistent");
+    try {
+      const config = await loadConfig();
+      expect(config).toEqual({});
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env["XDG_CONFIG_HOME"];
+      } else {
+        process.env["XDG_CONFIG_HOME"] = originalEnv;
+      }
+    }
+  });
+
+  it("throws when --config path does not exist", async () => {
+    const missingPath = path.join(tmpDir, "missing.json");
+    await expect(loadConfig(missingPath)).rejects.toThrow(
+      "Config file not found",
+    );
+  });
+
+  it("loads a valid config file", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.promises.writeFile(
+      configPath,
+      JSON.stringify({ debounceMs: 300 }),
+    );
+    const config = await loadConfig(configPath);
+    expect(config).toEqual({ debounceMs: 300 });
+  });
+
+  it("loads a full config file", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    const fullConfig = {
+      filter: { include: ["a"], exclude: ["b"] },
+      projectsDir: "/custom",
+      debounceMs: 200,
+      speaker: { maxLength: 50, truncationSeparator: "..." },
+    };
+    await fs.promises.writeFile(configPath, JSON.stringify(fullConfig));
+    const config = await loadConfig(configPath);
+    expect(config).toEqual(fullConfig);
+  });
+
+  it("throws on invalid JSON", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.promises.writeFile(configPath, "not json {{{");
+    await expect(loadConfig(configPath)).rejects.toThrow("Invalid JSON");
+  });
+
+  it("throws on schema validation error", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.promises.writeFile(
+      configPath,
+      JSON.stringify({ unknownKey: true }),
+    );
+    await expect(loadConfig(configPath)).rejects.toThrow("Invalid config file");
+  });
+
+  it("throws on invalid field type", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.promises.writeFile(
+      configPath,
+      JSON.stringify({ debounceMs: "not a number" }),
+    );
+    await expect(loadConfig(configPath)).rejects.toThrow("Invalid config file");
+  });
+});
+
+describe("resolveOptions", () => {
+  it("returns config values when no CLI args", () => {
+    const options = resolveOptions(
+      {
+        filter: { include: ["a"], exclude: ["b"] },
+        projectsDir: "/custom",
+        debounceMs: 300,
+        speaker: { maxLength: 50 },
+      },
+      {},
+    );
+    expect(options).toEqual({
+      watcher: {
+        projectsDir: "/custom",
+        filter: { include: ["a"], exclude: ["b"] },
+      },
+      speaker: { maxLength: 50 },
+      debounceMs: 300,
+    });
+  });
+
+  it("returns CLI args when no config", () => {
+    const options = resolveOptions({}, { include: ["x"], exclude: ["y"] });
+    expect(options).toEqual({
+      watcher: {
+        projectsDir: undefined,
+        filter: { include: ["x"], exclude: ["y"] },
+      },
+      speaker: undefined,
+      debounceMs: undefined,
+    });
+  });
+
+  it("CLI args override config filter", () => {
+    const options = resolveOptions(
+      { filter: { include: ["config-a"], exclude: ["config-b"] } },
+      { include: ["cli-a"] },
+    );
+    // include from CLI overrides config, but exclude from config is preserved
+    expect(options.watcher?.filter?.include).toEqual(["cli-a"]);
+    expect(options.watcher?.filter?.exclude).toEqual(["config-b"]);
+  });
+
+  it("CLI exclude overrides config exclude", () => {
+    const options = resolveOptions(
+      { filter: { exclude: ["config-b"] } },
+      { exclude: ["cli-b"] },
+    );
+    expect(options.watcher?.filter?.exclude).toEqual(["cli-b"]);
+  });
+
+  it("returns defaults when both config and CLI are empty", () => {
+    const options = resolveOptions({}, {});
+    expect(options).toEqual({
+      watcher: {
+        projectsDir: undefined,
+        filter: {},
+      },
+      speaker: undefined,
+      debounceMs: undefined,
+    });
+  });
+
+  it("preserves speaker and debounceMs from config", () => {
+    const options = resolveOptions(
+      {
+        debounceMs: 1000,
+        speaker: { maxLength: 200, truncationSeparator: "..." },
+      },
+      {},
+    );
+    expect(options.debounceMs).toBe(1000);
+    expect(options.speaker).toEqual({
+      maxLength: 200,
+      truncationSeparator: "...",
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,127 @@
+/**
+ * Configuration file loading and merging for cc-voice-reporter.
+ *
+ * Supports XDG Base Directory specification for config file placement:
+ *   $XDG_CONFIG_HOME/cc-voice-reporter/config.json
+ *   (default: ~/.config/cc-voice-reporter/config.json)
+ *
+ * CLI arguments take precedence over config file values.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { z } from "zod";
+import type { DaemonOptions } from "./daemon.js";
+import type { ProjectFilter } from "./watcher.js";
+
+export const ConfigSchema = z
+  .object({
+    /** Project filter (include/exclude patterns). */
+    filter: z
+      .object({
+        include: z.array(z.string()).optional(),
+        exclude: z.array(z.string()).optional(),
+      })
+      .optional(),
+
+    /** Projects directory to watch (default: ~/.claude/projects). */
+    projectsDir: z.string().optional(),
+
+    /** Debounce interval in ms for text messages (default: 500). */
+    debounceMs: z.number().int().positive().optional(),
+
+    /** Speaker options. */
+    speaker: z
+      .object({
+        /** Maximum character length before truncation (default: 100). */
+        maxLength: z.number().int().positive().optional(),
+        /** Separator inserted when truncating (default: "、中略、"). */
+        truncationSeparator: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict();
+
+export type Config = z.infer<typeof ConfigSchema>;
+
+/**
+ * Return the default config file path following XDG Base Directory spec.
+ *
+ * Uses $XDG_CONFIG_HOME if set, otherwise falls back to ~/.config.
+ */
+export function getDefaultConfigPath(): string {
+  const xdgConfigHome =
+    process.env["XDG_CONFIG_HOME"] ?? path.join(os.homedir(), ".config");
+  return path.join(xdgConfigHome, "cc-voice-reporter", "config.json");
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+/**
+ * Load and validate a config file.
+ *
+ * - If `configPath` is given and the file does not exist, throws an error.
+ * - If `configPath` is omitted, uses the XDG default path; missing file
+ *   returns an empty config (no error).
+ * - JSON parse errors and schema validation errors always throw.
+ */
+export async function loadConfig(configPath?: string): Promise<Config> {
+  const filePath = configPath ?? getDefaultConfigPath();
+
+  let content: string;
+  try {
+    content = await fs.promises.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (isNodeError(err) && err.code === "ENOENT") {
+      if (configPath !== undefined) {
+        throw new Error(`Config file not found: ${filePath}`);
+      }
+      return {};
+    }
+    throw err;
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    throw new Error(`Invalid JSON in config file ${filePath}`);
+  }
+
+  const result = ConfigSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(
+      `Invalid config file ${filePath}: ${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Merge a loaded config with CLI argument overrides into DaemonOptions.
+ *
+ * Priority: CLI args > config file > defaults (applied downstream).
+ * Arrays (include/exclude) are replaced wholesale, not merged.
+ */
+export function resolveOptions(
+  config: Config,
+  cliArgs: { include?: string[]; exclude?: string[] },
+): DaemonOptions {
+  const filter: ProjectFilter = {};
+  const includeSource = cliArgs.include ?? config.filter?.include;
+  const excludeSource = cliArgs.exclude ?? config.filter?.exclude;
+  if (includeSource) filter.include = includeSource;
+  if (excludeSource) filter.exclude = excludeSource;
+
+  return {
+    watcher: {
+      projectsDir: config.projectsDir,
+      filter,
+    },
+    speaker: config.speaker,
+    debounceMs: config.debounceMs,
+  };
+}


### PR DESCRIPTION
## Summary

- XDG Base Directory 準拠の設定ファイル (`~/.config/cc-voice-reporter/config.json`) でオプションを永続的に設定可能にした
- CLI 引数 `--config <path>` で設定ファイルのパスを上書き可能
- 設定可能項目: `filter` (include/exclude), `projectsDir`, `debounceMs`, `speaker` (maxLength, truncationSeparator)
- 優先順位: CLI 引数 > 設定ファイル > デフォルト値

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/config.ts` | 新規: ConfigSchema (zod, strict), loadConfig, resolveOptions, getDefaultConfigPath |
| `src/config.test.ts` | 新規: 22テスト（スキーマ検証、ファイル読み込み、マージロジック） |
| `src/cli.ts` | 変更: `--config` 引数追加、loadConfig + resolveOptions 統合 |

## 設定ファイル例

```json
{
  "filter": {
    "include": ["my-project"],
    "exclude": ["/Users/me/Workspace/tmp"]
  },
  "debounceMs": 300,
  "speaker": {
    "maxLength": 150,
    "truncationSeparator": "、省略、"
  }
}
```

## Test plan

- [x] `npm run build` — コンパイルエラーなし
- [x] `npm run lint` — リンターエラーなし
- [x] `npm test` — 178テスト全パス（新規22テスト含む）
- [ ] 設定ファイルなしで起動 → 現在と同じ動作
- [ ] `~/.config/cc-voice-reporter/config.json` に設定を書いて起動 → 反映される
- [ ] `--config ./test.json` で起動 → 指定ファイルの設定が反映
- [ ] 不正な JSON で起動 → わかりやすいエラーメッセージ
- [ ] CLI `--include` と設定ファイルの `filter.include` 両方指定 → CLI が優先

🤖 Generated with [Claude Code](https://claude.com/claude-code)