### PR TITLE
logger モジュールを導入して構造化ログ出力に移行

### DIFF
--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -39,8 +39,12 @@ cc-voice-reporter/
 │   └── dependabot.yml      # Dependabot 設定
 ├── src/                    # ソースコード
 │   ├── cli.ts              # デーモンの CLI エントリポイント（起動・シグナルハンドリング）
+│   ├── config.ts           # 設定ファイル読み込み・マージ（XDG 対応）
+│   ├── config.test.ts      # 設定のテスト
 │   ├── daemon.ts           # 常駐デーモン（watcher + parser + speaker 統合）
 │   ├── daemon.test.ts      # デーモンのテスト
+│   ├── logger.ts           # 軽量ロガー（レベル制御・構造化ログ出力）
+│   ├── logger.test.ts      # ロガーのテスト
 │   ├── parser.ts           # JSONL パーサー + メッセージ抽出（zod バリデーション）
 │   ├── parser.test.ts      # JSONL パーサーのテスト
 │   ├── speaker.ts          # say コマンドのキュー管理（排他制御）+ 長文切り詰め
@@ -76,7 +80,9 @@ cc-voice-reporter/
 メインのソースコード。transcript .jsonl 監視方式で動作する:
 
 - `cli.ts` — デーモンの CLI エントリポイント。Daemon の起動と SIGINT/SIGTERM での graceful shutdown を担当。
+- `config.ts` — 設定ファイル（XDG 準拠）の読み込み・バリデーション（zod）・CLI 引数とのマージ。logLevel、filter、speaker、translation 等を管理。
 - `daemon.ts` — 常駐デーモン。TranscriptWatcher + parser + Speaker + Translator を統合。テキストメッセージの requestId ベースデバウンス（500ms）、AskUserQuestion の即時読み上げ、ファイルパスからプロジェクト情報を抽出して Speaker に伝達。翻訳設定時はテキストを Ollama で翻訳してから読み上げ。
+- `logger.ts` — 軽量ロガーモジュール（外部依存なし）。ログレベル（debug/info/warn/error）に応じた出力制御。環境変数 `CC_VOICE_REPORTER_LOG_LEVEL` または config の `logLevel` で制御可能。
 - `translator.ts` — Ollama の `/api/chat` エンドポイントを Node.js 組み込み `fetch` で呼び出し、テキストを指定言語に翻訳する。翻訳失敗時は原文をそのまま返す（graceful degradation）。
 - `watcher.ts` — `~/.claude/projects/` 配下の .jsonl ファイルを chokidar v5 で監視し、新規追記行をコールバックで通知する。tail ロジック、サブエージェント対応、トランケーション検出、プロジェクト名抽出ユーティリティを実装済み。
 - `parser.ts` — transcript .jsonl の各行を zod スキーマでバリデーションし、assistant テキスト応答・tool_use 情報を抽出する。thinking・progress・tool_result 等は除外。

--- a/.ai-agent/tasks/20260221-introduce-logger/README.md
+++ b/.ai-agent/tasks/20260221-introduce-logger/README.md
@@ -1,0 +1,43 @@
+# logger 導入タスク
+
+Issue: https://github.com/mizunashi-mana/cc-voice-reporter/issues/41
+
+## 目的・ゴール
+
+`process.stderr.write()` による直接ログ出力を、自前の軽量 logger モジュールに移行し、ログレベル制御・フォーマット統一・テスト容易性を実現する。
+
+## 実装方針
+
+1. `src/logger.ts` を新規作成（外部依存なし）
+   - ログレベル: debug / info / warn / error
+   - 出力先: process.stderr
+   - フォーマット: `[cc-voice-reporter] {level}: {message}`
+   - デフォルトレベル: info
+2. config.json に `logLevel` フィールド追加
+3. 環境変数 `CC_VOICE_REPORTER_LOG_LEVEL` でもオーバーライド可能
+4. 既存の `process.stderr.write` を logger 経由に置き換え
+5. テスト追加
+
+## 完了条件
+
+- [x] `src/logger.ts` が作成されている
+- [x] `src/logger.test.ts` でユニットテストが通る
+- [x] 既存の `process.stderr.write` が全て logger 経由に置き換わっている
+- [x] config.json に `logLevel` を設定可能
+- [x] 環境変数 `CC_VOICE_REPORTER_LOG_LEVEL` で制御可能
+- [x] `npm run build` が通る
+- [x] `npm run lint` が通る
+- [x] `npm test` が通る
+
+## 作業ログ
+
+- 2026-02-21: タスク開始
+- 2026-02-21: 実装完了
+  - `src/logger.ts` — Logger クラス（debug/info/warn/error）、parseLogLevel、resolveLogLevel
+  - `src/logger.test.ts` — 13テスト追加
+  - `src/config.ts` — ConfigSchema に `logLevel` フィールド追加
+  - `src/cli.ts` — Logger を使用、resolveLogLevel で設定解決
+  - `src/daemon.ts` — 全 process.stderr.write を Logger 経由に置換
+  - `src/watcher.ts` — Logger を注入可能に、process.stderr.write を置換
+  - `src/translator.ts` — デフォルト onWarn を Logger 経由に変更
+  - `.ai-agent/structure.md` — logger.ts の説明追加

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ import type { ProjectFilter } from "./watcher.js";
 
 export const ConfigSchema = z
   .object({
+    /** Log level: "debug" | "info" | "warn" | "error" (default: "info"). */
+    logLevel: z.enum(["debug", "info", "warn", "error"]).optional(),
+
     /** Project filter (include/exclude patterns). */
     filter: z
       .object({

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Logger, parseLogLevel, resolveLogLevel } from "./logger.js";
+
+describe("parseLogLevel", () => {
+  it("parses valid log levels", () => {
+    expect(parseLogLevel("debug")).toBe("debug");
+    expect(parseLogLevel("info")).toBe("info");
+    expect(parseLogLevel("warn")).toBe("warn");
+    expect(parseLogLevel("error")).toBe("error");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseLogLevel("DEBUG")).toBe("debug");
+    expect(parseLogLevel("Info")).toBe("info");
+    expect(parseLogLevel("WARN")).toBe("warn");
+  });
+
+  it("returns undefined for invalid values", () => {
+    expect(parseLogLevel("verbose")).toBeUndefined();
+    expect(parseLogLevel("")).toBeUndefined();
+    expect(parseLogLevel("trace")).toBeUndefined();
+  });
+});
+
+describe("resolveLogLevel", () => {
+  afterEach(() => {
+    delete process.env["CC_VOICE_REPORTER_LOG_LEVEL"];
+  });
+
+  it("defaults to info", () => {
+    expect(resolveLogLevel()).toBe("info");
+  });
+
+  it("uses config level when provided", () => {
+    expect(resolveLogLevel("debug")).toBe("debug");
+  });
+
+  it("env var takes precedence over config", () => {
+    process.env["CC_VOICE_REPORTER_LOG_LEVEL"] = "error";
+    expect(resolveLogLevel("debug")).toBe("error");
+  });
+
+  it("falls back to config when env var is invalid", () => {
+    process.env["CC_VOICE_REPORTER_LOG_LEVEL"] = "invalid";
+    expect(resolveLogLevel("warn")).toBe("warn");
+  });
+
+  it("falls back to default when both are invalid", () => {
+    process.env["CC_VOICE_REPORTER_LOG_LEVEL"] = "invalid";
+    expect(resolveLogLevel("invalid")).toBe("info");
+  });
+});
+
+describe("Logger", () => {
+  it("outputs messages at or above the configured level", () => {
+    const output: string[] = [];
+    const logger = new Logger({
+      level: "info",
+      writeFn: (msg) => output.push(msg),
+    });
+
+    logger.debug("debug msg");
+    logger.info("info msg");
+    logger.warn("warn msg");
+    logger.error("error msg");
+
+    expect(output).toEqual([
+      "[cc-voice-reporter] info: info msg\n",
+      "[cc-voice-reporter] warn: warn msg\n",
+      "[cc-voice-reporter] error: error msg\n",
+    ]);
+  });
+
+  it("suppresses all below error level", () => {
+    const output: string[] = [];
+    const logger = new Logger({
+      level: "error",
+      writeFn: (msg) => output.push(msg),
+    });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(output).toEqual(["[cc-voice-reporter] error: e\n"]);
+  });
+
+  it("outputs everything at debug level", () => {
+    const output: string[] = [];
+    const logger = new Logger({
+      level: "debug",
+      writeFn: (msg) => output.push(msg),
+    });
+
+    logger.debug("d");
+    logger.info("i");
+    logger.warn("w");
+    logger.error("e");
+
+    expect(output).toHaveLength(4);
+  });
+
+  it("defaults to info level", () => {
+    const output: string[] = [];
+    const logger = new Logger({
+      writeFn: (msg) => output.push(msg),
+    });
+
+    logger.debug("should not appear");
+    logger.info("should appear");
+
+    expect(output).toHaveLength(1);
+    expect(output[0]).toContain("should appear");
+  });
+
+  it("uses process.stderr.write by default", () => {
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const logger = new Logger({ level: "info" });
+
+    logger.info("test message");
+
+    expect(spy).toHaveBeenCalledWith(
+      "[cc-voice-reporter] info: test message\n",
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,89 @@
+/**
+ * Lightweight logger module for cc-voice-reporter.
+ *
+ * Provides structured log output to stderr with level-based filtering.
+ * No external dependencies — uses process.stderr.write directly.
+ *
+ * Log level can be configured via:
+ *   1. Environment variable CC_VOICE_REPORTER_LOG_LEVEL
+ *   2. Config file logLevel field
+ *   3. Default: "info"
+ */
+
+const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const PREFIX = "[cc-voice-reporter]";
+
+/** Parse a string into a valid LogLevel, or return undefined. */
+export function parseLogLevel(value: string): LogLevel | undefined {
+  const lower = value.toLowerCase();
+  return LOG_LEVELS.includes(lower as LogLevel)
+    ? (lower as LogLevel)
+    : undefined;
+}
+
+export interface LoggerOptions {
+  /** Minimum log level to output (default: "info"). */
+  level?: LogLevel;
+  /** Custom write function (default: process.stderr.write). Used for testing. */
+  writeFn?: (message: string) => void;
+}
+
+export class Logger {
+  private readonly level: LogLevel;
+  private readonly writeFn: (message: string) => void;
+
+  constructor(options?: LoggerOptions) {
+    this.level = options?.level ?? "info";
+    this.writeFn =
+      options?.writeFn ?? ((msg) => process.stderr.write(msg));
+  }
+
+  debug(message: string): void {
+    this.log("debug", message);
+  }
+
+  info(message: string): void {
+    this.log("info", message);
+  }
+
+  warn(message: string): void {
+    this.log("warn", message);
+  }
+
+  error(message: string): void {
+    this.log("error", message);
+  }
+
+  private log(level: LogLevel, message: string): void {
+    if (LEVEL_PRIORITY[level] < LEVEL_PRIORITY[this.level]) return;
+    this.writeFn(`${PREFIX} ${level}: ${message}\n`);
+  }
+}
+
+/**
+ * Resolve the effective log level from environment variable and config.
+ *
+ * Priority: env var > config > "info"
+ */
+export function resolveLogLevel(configLevel?: string): LogLevel {
+  const envValue = process.env["CC_VOICE_REPORTER_LOG_LEVEL"];
+  if (envValue !== undefined) {
+    const parsed = parseLogLevel(envValue);
+    if (parsed !== undefined) return parsed;
+  }
+  if (configLevel !== undefined) {
+    const parsed = parseLogLevel(configLevel);
+    if (parsed !== undefined) return parsed;
+  }
+  return "info";
+}

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from "zod";
+import { Logger } from "./logger.js";
 
 /** Default timeout for Ollama API requests (30 seconds). */
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -47,9 +48,8 @@ export class Translator {
     this.model = options.ollama.model;
     this.baseUrl = options.ollama.baseUrl ?? "http://localhost:11434";
     this.timeoutMs = options.ollama.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.onWarn =
-      onWarn ??
-      ((msg) => process.stderr.write(`[cc-voice-reporter] ${msg}\n`));
+    const defaultLogger = new Logger();
+    this.onWarn = onWarn ?? ((msg) => defaultLogger.warn(msg));
   }
 
   /**


### PR DESCRIPTION
## 目的

`process.stderr.write()` による直接ログ出力を、自前の軽量 logger モジュールに移行し、ログレベル制御・フォーマット統一・テスト容易性を実現する。

Closes #41

## 変更概要

- `src/logger.ts` を新規作成 — Logger クラス（debug/info/warn/error）、parseLogLevel、resolveLogLevel を提供。外部依存なし
- `src/logger.test.ts` — 13件のユニットテスト追加
- `src/config.ts` — ConfigSchema に `logLevel` フィールド（"debug" | "info" | "warn" | "error"）を追加
- `src/cli.ts` — Logger を使用し、resolveLogLevel で環境変数 > config > デフォルトの優先度でログレベルを解決
- `src/daemon.ts` — 全 `process.stderr.write` を Logger 経由に置換。speak 系ログは debug レベル、パース警告は warn、エラーは error に分類
- `src/watcher.ts` — Logger を DI 可能に。ファイル監視のログを debug レベルに変更
- `src/translator.ts` — デフォルト onWarn を Logger 経由に変更
