### PR TITLE
デフォルトではテキストを中略しないようにする

### DIFF
--- a/.ai-agent/steering/tech.md
+++ b/.ai-agent/steering/tech.md
@@ -36,7 +36,7 @@ Claude Code ──書き込み──→ ~/.claude/projects/{path}/{session}.json
 
 - **TranscriptWatcher**（`src/watcher.ts`）: chokidar v5 でディレクトリ監視 + tail ロジック。ファイルポジション追跡による差分読み取り、サブエージェント .jsonl の監視対応、不完全行の安全な処理、ファイルトランケーション検出
 - **JSONL パーサー**（`src/parser.ts`）: transcript .jsonl の各行を zod スキーマでバリデーションし、assistant テキスト応答・tool_use 情報を抽出。thinking・progress・tool_result 等は除外
-- **Speaker**（`src/speaker.ts`）: macOS `say` コマンドの FIFO キュー管理。排他制御（1つずつ順番に実行）、長文メッセージの中間省略（デフォルト100文字）、プロジェクト・セッション対応キュー（同一プロジェクト+同一セッション > 同一プロジェクト > FIFO の3段階優先取り出し、プロジェクト切り替えアナウンス）、graceful shutdown
+- **Speaker**（`src/speaker.ts`）: macOS `say` コマンドの FIFO キュー管理。排他制御（1つずつ順番に実行）、長文メッセージの中間省略（設定で `maxLength` を指定した場合のみ適用、デフォルトは中略なし）、プロジェクト・セッション対応キュー（同一プロジェクト+同一セッション > 同一プロジェクト > FIFO の3段階優先取り出し、プロジェクト切り替えアナウンス）、graceful shutdown
 - **Translator**（`src/translator.ts`）: Ollama の `/api/chat` エンドポイントを使ったテキスト翻訳。翻訳失敗時は原文をそのまま返す（graceful degradation）
 - **Summarizer**（`src/summarizer.ts`）: Ollama の `/api/chat` を使った定期要約通知。Daemon からイベント（tool_use, text）を蓄積し、設定された間隔で自然な日本語の要約文を生成して音声で通知。イベントが無い期間はスキップ
 - **Daemon**（`src/daemon.ts`）: TranscriptWatcher + parser + Speaker + Translator + Summarizer を統合。テキストメッセージの requestId ベースデバウンス（500ms）、AskUserQuestion の即時読み上げ、ファイルパスからプロジェクト情報を抽出して Speaker に伝達。翻訳設定時はテキストを Ollama で翻訳してから読み上げ。narration 制御（サマリーモード時は逐次読み上げを無効化）
@@ -48,7 +48,7 @@ Claude Code ──書き込み──→ ~/.claude/projects/{path}/{session}.json
 
 - macOS `say` コマンドによる音声合成
 - Speaker クラスによるキュー管理で読み上げの排他制御
-- 長文テキストの中間省略（デフォルト100文字、先頭50文字 + 「、中略、」 + 末尾50文字）
+- 長文テキストの中間省略（設定で `speaker.maxLength` を指定した場合のみ適用）
 - プロジェクト切り替え時の音声アナウンス
 
 ## 開発環境

--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -88,7 +88,7 @@ cc-voice-reporter/
 - `translator.ts` — Ollama の `/api/chat` エンドポイントを Node.js 組み込み `fetch` で呼び出し、テキストを指定言語に翻訳する。翻訳失敗時は原文をそのまま返す（graceful degradation）。
 - `watcher.ts` — `~/.claude/projects/` 配下の .jsonl ファイルを chokidar v5 で監視し、新規追記行をコールバックで通知する。tail ロジック、サブエージェント対応、トランケーション検出、プロジェクト名抽出ユーティリティを実装済み。
 - `parser.ts` — transcript .jsonl の各行を zod スキーマでバリデーションし、assistant テキスト応答・tool_use 情報を抽出する。thinking・progress・tool_result 等は除外。
-- `speaker.ts` — macOS `say` コマンドの FIFO キュー管理。排他制御（1つずつ順番に実行）、長文メッセージの中間省略（デフォルト100文字）、プロジェクト・セッション対応キュー（同一プロジェクト+同一セッション > 同一プロジェクト > FIFO の3段階優先取り出し、プロジェクト切り替えアナウンス）、graceful shutdown（dispose）を提供。
+- `speaker.ts` — macOS `say` コマンドの FIFO キュー管理。排他制御（1つずつ順番に実行）、長文メッセージの中間省略（設定で `maxLength` を指定した場合のみ適用、デフォルトは中略なし）、プロジェクト・セッション対応キュー（同一プロジェクト+同一セッション > 同一プロジェクト > FIFO の3段階優先取り出し、プロジェクト切り替えアナウンス）、graceful shutdown（dispose）を提供。
 - `summarizer.ts` — Ollama の `/api/chat` を使った定期要約通知。Daemon からイベント（tool_use, text）を蓄積し、設定された間隔で自然な日本語の要約文を生成して音声で通知。イベントが無い期間はスキップ。
 
 ### .ai-agent/

--- a/.ai-agent/tasks/20260221-disable-default-truncation/README.md
+++ b/.ai-agent/tasks/20260221-disable-default-truncation/README.md
@@ -1,0 +1,27 @@
+# デフォルトでテキスト中略を無効化 (Issue #37)
+
+## 目的・ゴール
+
+Speaker の `maxLength` デフォルト値を無制限に変更し、設定で明示的に指定した場合のみ中略を適用する。
+
+## 実装方針
+
+1. `src/speaker.ts`: `maxLength` のデフォルト値を `100` → `Infinity` に変更
+2. `src/speaker.test.ts`: デフォルト中略テストを「デフォルトでは中略しない」テストに書き換え
+3. `src/config.ts`: コメントの「default: 100」を更新
+4. ドキュメント更新（`tech.md`, `structure.md`）
+
+## 完了条件
+
+- [x] `maxLength` 未指定時にテキストが中略されないこと
+- [x] `maxLength` を設定した場合は従来通り中略が動作すること
+- [x] `npm run build` / `npm run lint` / `npm test` がすべてパスすること
+- [x] ドキュメントが更新されていること
+
+## 作業ログ
+
+- `speaker.ts`: デフォルト `maxLength` を `100` → `Infinity` に変更
+- `speaker.test.ts`: デフォルト100文字テスト2件を「デフォルトでは中略しない」テスト1件に置き換え
+- `config.ts`: コメント更新
+- `tech.md`, `structure.md`: Speaker の説明を更新
+- build / lint / test すべてパス（300 tests passed）

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export const ConfigSchema = z
     /** Speaker options. */
     speaker: z
       .object({
-        /** Maximum character length before truncation (default: 100). */
+        /** Maximum character length before truncation (default: no truncation). */
         maxLength: z.number().int().positive().optional(),
         /** Separator inserted when truncating (default: "、中略、"). */
         truncationSeparator: z.string().optional(),

--- a/src/speaker.test.ts
+++ b/src/speaker.test.ts
@@ -160,19 +160,11 @@ describe("Speaker", () => {
       expect(executorSpy).toHaveBeenCalledWith("123...789");
     });
 
-    it("uses default maxLength of 100 with middle ellipsis", () => {
+    it("does not truncate by default (no maxLength specified)", () => {
       setup();
-      const longMessage = "あ".repeat(50) + "い".repeat(51);
+      const longMessage = "あ".repeat(500);
       speaker.speak(longMessage);
-      const called = executorSpy.mock.calls[0]![0] as string;
-      expect(called).toBe("あ".repeat(50) + "、中略、" + "い".repeat(50));
-    });
-
-    it("does not truncate at exactly 100 characters", () => {
-      setup();
-      const exactMessage = "あ".repeat(100);
-      speaker.speak(exactMessage);
-      expect(executorSpy).toHaveBeenCalledWith(exactMessage);
+      expect(executorSpy).toHaveBeenCalledWith(longMessage);
     });
   });
 

--- a/src/speaker.ts
+++ b/src/speaker.ts
@@ -28,7 +28,7 @@ interface QueueItem {
 }
 
 export interface SpeakerOptions {
-  /** Maximum character length before truncation (default: 200). */
+  /** Maximum character length before truncation (default: Infinity — no truncation). */
   maxLength?: number;
   /** Suffix inserted between head and tail when truncated (default: "、中略、"). */
   truncationSeparator?: string;
@@ -54,7 +54,7 @@ export class Speaker {
   private currentSession: string | null = null;
 
   constructor(options?: SpeakerOptions) {
-    this.maxLength = options?.maxLength ?? 100;
+    this.maxLength = options?.maxLength ?? Infinity;
     this.truncationSeparator = options?.truncationSeparator ?? "、中略、";
     this.executor =
       options?.executor ?? ((message) => execFile("say", [message]));


### PR DESCRIPTION
## 目的

音声レポートでは全文を聞きたいケースが多く、デフォルトで100文字に中略されると重要な情報が欠落する可能性がある。中略が必要なユーザーは設定ファイルで `speaker.maxLength` を指定すればよいため、デフォルトでは中略しないように変更する。

Closes #37

## 変更概要

- `Speaker` の `maxLength` デフォルト値を `100` → `Infinity`（無制限）に変更
- 設定ファイルで `speaker.maxLength` を明示的に指定した場合のみ中略を適用
- テスト・ドキュメント（tech.md, structure.md）を更新