### PR TITLE
要約失敗時にその旨とイベント件数を音声で報告する

### DIFF
--- a/.ai-agent/tasks/20260223-speak-summary-failure/README.md
+++ b/.ai-agent/tasks/20260223-speak-summary-failure/README.md
@@ -1,0 +1,31 @@
+# 要約失敗時にその旨とイベント件数を音声で報告する
+
+Issue: https://github.com/mizunashi-mana/cc-voice-reporter/issues/92
+
+## 目的・ゴール
+
+Ollama による要約生成が失敗した場合、失敗した旨と要約対象だったイベントの件数を音声で報告する。
+
+## 実装方針
+
+1. `messages.ts` の `Messages` インターフェースに `summaryFailed` メッセージを追加
+2. `summarizer.ts` で `getMessages` を使って Messages を取得し、catch ブロックで `speakFn` を呼び出す
+3. テストを更新
+
+## 完了条件
+
+- [x] `messages.ts` に `summaryFailed` メッセージが追加されている
+- [x] `summarizer.ts` の catch ブロックで音声報告が行われる
+- [x] 既存テストが通る
+- [x] 新規テスト（失敗時に音声報告されること）が追加されている
+- [x] `npm run build` が通る
+- [x] `npm run lint` が通る
+- [x] `npm test` が通る
+
+## 作業ログ
+
+- `messages.ts`: `Messages` インターフェースに `summaryFailed: (eventCount: number) => string` を追加。日本語・英語の両メッセージを定義
+- `summarizer.ts`: `getMessages` をインポートし、コンストラクタで `messages` を保持。`doFlush` の catch ブロックで `this.speakFn(this.messages.summaryFailed(events.length))` を呼び出し
+- `messages.test.ts`: 日本語・英語の `summaryFailed` テストを追加（2件）
+- `summarizer.test.ts`: 失敗時の既存テスト 3 件を更新（音声報告の検証追加）、新規テスト 3 件追加（件数検証、日本語メッセージ、英語メッセージ）
+- Build / Test (320 passed) / Lint 全てパス

--- a/packages/cc-voice-reporter/src/monitor/messages.test.ts
+++ b/packages/cc-voice-reporter/src/monitor/messages.test.ts
@@ -18,6 +18,12 @@ describe('getMessages', () => {
         '別のプロジェクト「my-app」の実行内容を再生します',
       );
     });
+
+    it('returns Japanese summary failed message', () => {
+      expect(messages.summaryFailed(5)).toBe(
+        '要約の生成に失敗しました。5件のアクティビティがありました。',
+      );
+    });
   });
 
   describe('en (English)', () => {
@@ -36,6 +42,12 @@ describe('getMessages', () => {
     it('returns English project switch message', () => {
       expect(messages.projectSwitch('my-app')).toBe(
         'Playing content from another project, my-app',
+      );
+    });
+
+    it('returns English summary failed message', () => {
+      expect(messages.summaryFailed(3)).toBe(
+        'Failed to generate summary. There were 3 activities.',
       );
     });
   });

--- a/packages/cc-voice-reporter/src/monitor/messages.ts
+++ b/packages/cc-voice-reporter/src/monitor/messages.ts
@@ -13,6 +13,8 @@ export interface Messages {
   askUserQuestion: (question: string) => string;
   /** Spoken when the speaker switches to a different project's messages. */
   projectSwitch: (displayName: string) => string;
+  /** Spoken when Ollama summary generation fails. */
+  summaryFailed: (eventCount: number) => string;
 }
 
 const ja: Messages = {
@@ -20,6 +22,8 @@ const ja: Messages = {
   askUserQuestion: (question: string) => `確認待ち: ${question}`,
   projectSwitch: (displayName: string) =>
     `別のプロジェクト「${displayName}」の実行内容を再生します`,
+  summaryFailed: (eventCount: number) =>
+    `要約の生成に失敗しました。${String(eventCount)}件のアクティビティがありました。`,
 };
 
 const en: Messages = {
@@ -27,6 +31,8 @@ const en: Messages = {
   askUserQuestion: (question: string) => `Confirmation: ${question}`,
   projectSwitch: (displayName: string) =>
     `Playing content from another project, ${displayName}`,
+  summaryFailed: (eventCount: number) =>
+    `Failed to generate summary. There were ${String(eventCount)} activities.`,
 };
 
 const locales: Record<string, Messages> = { ja, en };

--- a/packages/cc-voice-reporter/src/monitor/summarizer.ts
+++ b/packages/cc-voice-reporter/src/monitor/summarizer.ts
@@ -15,6 +15,7 @@
  */
 
 import { z } from 'zod';
+import { getMessages, type Messages } from './messages.js';
 import type { Logger } from './logger.js';
 
 /** Default summary interval (5 seconds). */
@@ -85,6 +86,7 @@ export class Summarizer {
   private readonly systemPrompt: string;
   private readonly speakFn: SummarySpeakFn;
   private readonly logger: Logger;
+  private readonly messages: Messages;
 
   /** Events accumulated per session. */
   private readonly eventsBySession = new Map<string, ActivityEvent[]>();
@@ -112,6 +114,7 @@ export class Summarizer {
     this.systemPrompt = buildSystemPrompt(options.language);
     this.speakFn = speakFn;
     this.logger = logger;
+    this.messages = getMessages(options.language);
     this.logger.debug(`summary system prompt: ${this.systemPrompt}`);
   }
 
@@ -203,6 +206,7 @@ export class Summarizer {
         this.logger.warn(
           `summary error: ${error instanceof Error ? error.message : String(error)}`,
         );
+        this.speakFn(this.messages.summaryFailed(events.length));
       }
     }
   }


### PR DESCRIPTION
## Summary

- Ollama による要約生成が失敗した際、`speakFn` で失敗メッセージとイベント件数を音声報告するようにした
- `Messages` インターフェースに `summaryFailed` メッセージを追加（日本語・英語）
- `Summarizer` の `doFlush` catch ブロックで `speakFn(messages.summaryFailed(events.length))` を呼び出し

Closes #92

## Test plan

- [x] `npm run build` でコンパイルエラーなし
- [x] `npm run lint` でリンターエラーなし
- [x] `npm test` で全テスト通過（320 passed）
- [ ] Ollama 停止状態で実際に音声報告されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)