### PR TITLE
AskUserQuestion の音声通知で質問内容を先に読み上げる

### DIFF
--- a/.ai-agent/tasks/20260223-reorder-ask-user-question-message/README.md
+++ b/.ai-agent/tasks/20260223-reorder-ask-user-question-message/README.md
@@ -1,0 +1,27 @@
+# AskUserQuestion メッセージ順序改善
+
+## 目的・ゴール
+
+`AskUserQuestion` の音声通知で「確認待ち」プレフィックスが質問内容より先に読み上げられ、文脈が掴みづらい問題を修正する（Issue #94）。
+
+## 実装方針
+
+`messages.ts` のメッセージテンプレートを変更し、質問内容を先に読み上げた後に「確認待ちです」を案内する形式にする。
+
+- 日本語: `確認待ち: ${question}` → `${question}。確認待ちです`
+- 英語: `Confirmation: ${question}` → `${question}. Awaiting confirmation`
+
+## 完了条件
+
+- [x] `messages.ts` のテンプレート変更
+- [x] `messages.test.ts` のテスト期待値更新
+- [x] `npm run build` 成功
+- [x] `npm run lint` 成功
+- [x] `npm test` 成功
+
+## 作業ログ
+
+- `messages.ts`: 日本語・英語両方のテンプレートを質問先読み形式に変更
+- `messages.test.ts`: テスト期待値を新形式に更新
+- `daemon.test.ts`: 6箇所の期待値を新形式に更新
+- ビルド・リント・テスト全て成功

--- a/packages/cc-voice-reporter/src/monitor/daemon.test.ts
+++ b/packages/cc-voice-reporter/src/monitor/daemon.test.ts
@@ -113,7 +113,7 @@ describe('Daemon', () => {
 
       daemon.handleLines([line]);
       // AskUserQuestion is spoken immediately (no debounce)
-      expect(spoken).toEqual(['Confirmation: どの方式を使いますか？']);
+      expect(spoken).toEqual(['どの方式を使いますか？. Awaiting confirmation']);
     });
 
     it('speaks multiple questions joined together', () => {
@@ -142,7 +142,7 @@ describe('Daemon', () => {
       });
 
       daemon.handleLines([line]);
-      expect(spoken).toEqual(['Confirmation: 質問1？ 質問2？']);
+      expect(spoken).toEqual(['質問1？ 質問2？. Awaiting confirmation']);
     });
 
     it('does not speak AskUserQuestion with empty questions', () => {
@@ -251,7 +251,7 @@ describe('Daemon', () => {
       // (turn complete is processed inline, AskUserQuestion is deferred)
       expect(spoken).toEqual([
         'Waiting for input',
-        'Confirmation: Which approach?',
+        'Which approach?. Awaiting confirmation',
       ]);
     });
   });
@@ -367,7 +367,7 @@ describe('Daemon', () => {
       );
 
       expect(spokenWithProject).toHaveLength(1);
-      expect(spokenWithProject[0]!.message).toBe('Confirmation: 確認しますか？');
+      expect(spokenWithProject[0]!.message).toBe('確認しますか？. Awaiting confirmation');
       expect(spokenWithProject[0]!.project).toEqual({
         dir: '-proj-a',
         displayName: 'a',
@@ -575,7 +575,7 @@ describe('Daemon', () => {
       });
 
       daemon.handleLines([line]);
-      expect(spoken).toEqual(['Confirmation: Which option?']);
+      expect(spoken).toEqual(['Which option?. Awaiting confirmation']);
     });
 
     it('falls back to English for unknown language codes', () => {
@@ -693,9 +693,9 @@ describe('Daemon', () => {
 
       // Summary should come before "確認待ち"
       expect(spoken).toContain('コードを確認しました');
-      expect(spoken).toContain('Confirmation: どちらにしますか？');
+      expect(spoken).toContain('どちらにしますか？. Awaiting confirmation');
       const summaryIdx = spoken.indexOf('コードを確認しました');
-      const askIdx = spoken.indexOf('Confirmation: どちらにしますか？');
+      const askIdx = spoken.indexOf('どちらにしますか？. Awaiting confirmation');
       expect(summaryIdx).toBeLessThan(askIdx);
     });
 

--- a/packages/cc-voice-reporter/src/monitor/messages.test.ts
+++ b/packages/cc-voice-reporter/src/monitor/messages.test.ts
@@ -10,7 +10,7 @@ describe('getMessages', () => {
     });
 
     it('returns Japanese ask user question message', () => {
-      expect(messages.askUserQuestion('質問内容')).toBe('確認待ち: 質問内容');
+      expect(messages.askUserQuestion('質問内容')).toBe('質問内容。確認待ちです');
     });
 
     it('returns Japanese project switch message', () => {
@@ -35,7 +35,7 @@ describe('getMessages', () => {
 
     it('returns English ask user question message', () => {
       expect(messages.askUserQuestion('Which option?')).toBe(
-        'Confirmation: Which option?',
+        'Which option?. Awaiting confirmation',
       );
     });
 

--- a/packages/cc-voice-reporter/src/monitor/messages.ts
+++ b/packages/cc-voice-reporter/src/monitor/messages.ts
@@ -19,7 +19,7 @@ export interface Messages {
 
 const ja: Messages = {
   turnComplete: '入力待ちです',
-  askUserQuestion: (question: string) => `確認待ち: ${question}`,
+  askUserQuestion: (question: string) => `${question}。確認待ちです`,
   projectSwitch: (displayName: string) =>
     `別のプロジェクト「${displayName}」の実行内容を再生します`,
   summaryFailed: (eventCount: number) =>
@@ -28,7 +28,7 @@ const ja: Messages = {
 
 const en: Messages = {
   turnComplete: 'Waiting for input',
-  askUserQuestion: (question: string) => `Confirmation: ${question}`,
+  askUserQuestion: (question: string) => `${question}. Awaiting confirmation`,
   projectSwitch: (displayName: string) =>
     `Playing content from another project, ${displayName}`,
   summaryFailed: (eventCount: number) =>


### PR DESCRIPTION
## 目的

`AskUserQuestion` の音声通知が「確認待ち: {質問内容}」の形式で読み上げられるため、質問の内容より先に「確認待ち」が読み上げられ、何の確認なのかわからないまま聞くことになる問題を修正する。

Closes #94

## 変更概要

- `messages.ts` のメッセージテンプレートを質問内容が先に読み上げられる形式に変更
  - 日本語: `確認待ち: ${question}` → `${question}。確認待ちです`
  - 英語: `Confirmation: ${question}` → `${question}. Awaiting confirmation`
- `messages.test.ts` / `daemon.test.ts` のテスト期待値を新形式に更新