### PR TITLE
publish ワークフロー名を publish に変更

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: publish
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 目的

publish ワークフローの name を簡潔にする。

## 変更概要

- ワークフロー名を `Publish to npm` から `publish` に変更
