### PR TITLE
README のコマンドを npx ベースに変更し、バージョンを 1.0.0 に更新

### DIFF
--- a/.ai-agent/tasks/20260223-readme-npx-and-v1/README.md
+++ b/.ai-agent/tasks/20260223-readme-npx-and-v1/README.md
@@ -1,0 +1,29 @@
+# README の npx ベース化 + v1.0.0 リリース準備
+
+## 目的・ゴール
+
+README のコマンド例を `cc-voice-reporter` から `npx @mizunashi_mana/cc-voice-reporter` に変更し、npx で直接実行できることを明示する。また、"Under active development." のステータス表記を削除し、バージョンを 1.0.0 に変更する。
+
+## 実装方針
+
+1. README.md の Usage セクションのコマンド例を全て `npx @mizunashi_mana/cc-voice-reporter` ベースに変更
+2. Configuration セクションのコマンド例も同様に変更
+3. `> **Status**: Under active development.` の行を削除
+4. `packages/cc-voice-reporter/package.json` の version を `"1.0.0"` に変更
+
+## 完了条件
+
+- [x] README の全コマンド例が `npx @mizunashi_mana/cc-voice-reporter` ベースになっている
+- [x] "Under active development." が削除されている
+- [x] package.json の version が `"1.0.0"` になっている
+- [x] `npm run build` が成功する
+- [x] `npm run lint` が成功する
+- [x] `npm test` が成功する
+
+## 作業ログ
+
+- README.md: Usage セクションの全コマンド例を `npx @mizunashi_mana/cc-voice-reporter` に変更
+- README.md: Configuration セクションの `cc-voice-reporter config init` を `npx @mizunashi_mana/cc-voice-reporter config init` に変更
+- README.md: `> **Status**: Under active development.` を削除
+- packages/cc-voice-reporter/package.json: version を `"0.3.0"` → `"1.0.0"` に変更
+- ビルド・リント・テスト全て成功

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Real-time voice reporting for Claude Code — hear what Claude is doing without 
 
 cc-voice-reporter runs as a background daemon that monitors Claude Code's transcript files and speaks out what's happening: when Claude finishes a task, when it needs your confirmation, and periodic summaries of its activity. You can step away from your desk and still know exactly what Claude is up to.
 
-> **Status**: Under active development.
-
 ## When is this useful?
 
 - **Multitasking** — You're working on something else while Claude runs a long task. Voice notifications tell you when it's done or needs input.
@@ -51,31 +49,31 @@ That's it. Open Claude Code in another terminal and start a session — you'll h
 
 ```bash
 # Show version
-cc-voice-reporter --version
+npx @mizunashi_mana/cc-voice-reporter --version
 
 # Show help
-cc-voice-reporter --help
-cc-voice-reporter monitor --help
+npx @mizunashi_mana/cc-voice-reporter --help
+npx @mizunashi_mana/cc-voice-reporter monitor --help
 
 # Start the daemon
-cc-voice-reporter monitor
+npx @mizunashi_mana/cc-voice-reporter monitor
 
 # Watch only specific projects
-cc-voice-reporter monitor --include my-project --exclude scratch
+npx @mizunashi_mana/cc-voice-reporter monitor --include my-project --exclude scratch
 
 # Use a custom config file
-cc-voice-reporter monitor --config /path/to/config.json
+npx @mizunashi_mana/cc-voice-reporter monitor --config /path/to/config.json
 
 # Initialize a config file
-cc-voice-reporter config init
+npx @mizunashi_mana/cc-voice-reporter config init
 
 # Show config file path
-cc-voice-reporter config path
+npx @mizunashi_mana/cc-voice-reporter config path
 
 # Manage tracked projects
-cc-voice-reporter tracking list
-cc-voice-reporter tracking add /path/to/project
-cc-voice-reporter tracking remove /path/to/project
+npx @mizunashi_mana/cc-voice-reporter tracking list
+npx @mizunashi_mana/cc-voice-reporter tracking add /path/to/project
+npx @mizunashi_mana/cc-voice-reporter tracking remove /path/to/project
 ```
 
 ### Commands
@@ -106,7 +104,7 @@ cc-voice-reporter tracking remove /path/to/project
 The easiest way to create a config file is the interactive setup wizard:
 
 ```bash
-cc-voice-reporter config init
+npx @mizunashi_mana/cc-voice-reporter config init
 ```
 
 This detects your system locale, available TTS commands, and Ollama models, then generates a config file at `~/.config/cc-voice-reporter/config.json`. Use `--non-interactive` to generate a default template without prompts.

--- a/packages/cc-voice-reporter/package.json
+++ b/packages/cc-voice-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizunashi_mana/cc-voice-reporter",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Real-time voice reporting for Claude Code",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 目的

README のコマンド例を npx ベースにすることで、グローバルインストール不要で利用できることを明示する。また、安定版として v1.0.0 をリリースするための準備。

## 変更概要

- Usage セクションの全コマンド例を `cc-voice-reporter` から `npx @mizunashi_mana/cc-voice-reporter` に変更
- Configuration セクションのコマンド例も同様に変更
- `> **Status**: Under active development.` のステータス表記を削除
- `packages/cc-voice-reporter/package.json` の version を `0.3.0` → `1.0.0` に変更