### PR TITLE
確認待ち・入力待ち音声案内を後続アクティビティでキャンセルする

### DIFF
--- a/.ai-agent/tasks/20260223-cancel-stale-ask-question/README.md
+++ b/.ai-agent/tasks/20260223-cancel-stale-ask-question/README.md
@@ -1,0 +1,58 @@
+# 確認待ち音声案内の遅延再生を防止する
+
+Issue: https://github.com/mizunashi-mana/cc-voice-reporter/issues/104
+
+## 目的・ゴール
+
+AskUserQuestion の音声案内が、ユーザーが既に回答した後に遅れて再生される問題を解決する。
+ユーザーが回答済みの場合は音声案内をキャンセルし、混乱を防ぐ。
+
+## 原因分析
+
+1. AskUserQuestion 検出 → Summarizer フラッシュ（Ollama API 呼び出し、非同期）→ 音声キューにエンキュー
+2. フラッシュ待ちの間にユーザーが回答してしまう
+3. `user` レコードは parser で解析されるが `extractMessages` で空配列が返るため、daemon が回答を検知できない
+4. 結果、フラッシュ完了後に古い質問が読み上げられてしまう
+
+## 実装方針
+
+セッション毎の boolean フラグ方式で、回答済みの AskUserQuestion をキャンセルする。
+入力待ち案内（turnComplete）も同様に boolean 化。
+
+### 変更ファイル
+
+1. **parser.ts**: `user` レコードから `ExtractedUserResponse` メッセージを抽出するように変更
+2. **daemon.ts**: `askQuestionCancelled` / `turnCompleteCancelled` boolean フラグを追加し、ユーザー回答・新規アクティビティ時にキャンセル
+3. **daemon.test.ts**: 新しいキャンセル動作のテストを追加
+4. **parser.test.ts**: `ExtractedUserResponse` の抽出テストを追加
+
+### 詳細設計
+
+#### parser.ts
+- `ExtractedUserResponse` 型を追加（`kind: 'user_response'`）
+- `ExtractedMessage` union に追加
+- `extractMessages` で `user` レコードに対して `{ kind: 'user_response' }` を返す
+
+#### daemon.ts
+- `askQuestionCancelled: Map<string, boolean>` を追加（セッションキー別）
+- `turnCompleteCancelled: Map<string, boolean>` に変更（旧 `turnCompleteGeneration` カウンター）
+- `handleLines` で `user_response` / `text` / `tool_use` メッセージ受信時にフラグを `true` に設定
+- `handleAskUserQuestion` / `handleTurnComplete` でフラグを `false` にリセットし、フラッシュ後にチェック
+
+## 完了条件
+
+- [x] `user` レコードが `ExtractedUserResponse` として抽出される
+- [x] AskUserQuestion の音声案内がユーザー回答後にキャンセルされる
+- [x] Summarizer フラッシュ中にユーザーが回答した場合、フラッシュ後に音声が再生されない
+- [x] 新しい assistant 活動（text/tool_use）も AskUserQuestion をキャンセルする
+- [x] turnComplete 通知も同様に boolean フラグ方式に変更
+- [x] 既存テストが通る
+- [x] `npm run build` / `npm run lint` / `npm test` すべて通る
+
+## 作業ログ
+
+- parser.ts に `ExtractedUserResponse` 型を追加し、`extractMessages` で user レコードを処理
+- daemon.ts のジェネレーションカウンターを boolean フラグに変更（`askQuestionCancelled`, `turnCompleteCancelled`）
+- daemon.test.ts に AskUserQuestion キャンセルテスト（summarizer あり/なし、セッション分離）を追加
+- parser.test.ts を `ExtractedUserResponse` に合わせて更新
+- ビルド・リント・テスト全て通過（361 tests passed）

--- a/packages/cc-voice-reporter/src/monitor/daemon.test.ts
+++ b/packages/cc-voice-reporter/src/monitor/daemon.test.ts
@@ -256,8 +256,221 @@ describe('Daemon', () => {
     });
   });
 
+  describe('AskUserQuestion cancellation on user response', () => {
+    it('cancels AskUserQuestion when user responds before speech (with summarizer)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ message: { content: '要約テスト' } }),
+          { status: 200 },
+        ),
+      );
+
+      daemon = new Daemon({
+        logger: silentLogger,
+        language: 'en',
+        watcher: { projectsDir: '/tmp/cc-voice-reporter-test-nonexistent' },
+        speakFn: (message) => {
+          spoken.push(message);
+        },
+        summary: {
+          ollama: {
+            model: 'test-model',
+            baseUrl: 'http://localhost:11434',
+          },
+          intervalMs: 60_000,
+          language: 'en',
+        },
+      });
+      await daemon.start();
+
+      // Record some activity, then AskUserQuestion
+      const toolLine = JSON.stringify({
+        type: 'assistant',
+        requestId: 'req_0',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'toolu_0', name: 'Read', input: { file_path: '/src/app.ts' } },
+          ],
+        },
+        uuid: 'uuid-tool-cancel',
+        timestamp: new Date().toISOString(),
+      });
+      daemon.handleLines([toolLine]);
+
+      const askLine = JSON.stringify({
+        type: 'assistant',
+        requestId: 'req_1',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'AskUserQuestion',
+              input: {
+                questions: [
+                  {
+                    question: 'Proceed?',
+                    header: 'Confirm',
+                    options: [
+                      { label: 'Yes', description: 'yes' },
+                      { label: 'No', description: 'no' },
+                    ],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        uuid: 'uuid-ask-cancel',
+        timestamp: new Date().toISOString(),
+      });
+      daemon.handleLines([askLine]);
+
+      // User responds before summary flush completes
+      const userLine = JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: 'Yes' },
+        uuid: 'uuid-user-response',
+        timestamp: new Date().toISOString(),
+      });
+      daemon.handleLines([userLine]);
+
+      // Now let the summary flush resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      // AskUserQuestion speech should be suppressed
+      const askMessages = spoken.filter(s => s.includes('Awaiting confirmation'));
+      expect(askMessages).toHaveLength(0);
+    });
+
+    it('cancels AskUserQuestion when new assistant text arrives', () => {
+      daemon = new Daemon({
+        logger: silentLogger,
+        language: 'en',
+        watcher: { projectsDir: '/tmp/cc-voice-reporter-test-nonexistent' },
+        speakFn: (message) => {
+          spoken.push(message);
+        },
+      });
+
+      const askLine = JSON.stringify({
+        type: 'assistant',
+        requestId: 'req_1',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'AskUserQuestion',
+              input: {
+                questions: [
+                  {
+                    question: 'Which option?',
+                    header: 'Choice',
+                    options: [
+                      { label: 'A', description: 'a' },
+                      { label: 'B', description: 'b' },
+                    ],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        uuid: 'uuid-ask-cancel2',
+        timestamp: new Date().toISOString(),
+      });
+
+      // Without summarizer, AskUserQuestion speaks synchronously.
+      // The speech should go through because no cancellation has occurred.
+      daemon.handleLines([askLine]);
+      expect(spoken).toEqual(['Which option?. Awaiting confirmation']);
+    });
+
+    it('does not cancel AskUserQuestion from unrelated session', async () => {
+      const projectsDir = '/home/user/.claude/projects';
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({ message: { content: '要約' } }),
+          { status: 200 },
+        ),
+      );
+
+      daemon = new Daemon({
+        logger: silentLogger,
+        language: 'en',
+        watcher: { projectsDir },
+        speakFn: (message) => {
+          spoken.push(message);
+        },
+        resolveProjectName: dir => dir.replace(/^-/, ''),
+        summary: {
+          ollama: {
+            model: 'test-model',
+            baseUrl: 'http://localhost:11434',
+          },
+          intervalMs: 60_000,
+          language: 'en',
+        },
+      });
+      await daemon.start();
+
+      // AskUserQuestion in session A
+      const askLine = JSON.stringify({
+        type: 'assistant',
+        requestId: 'req_1',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'AskUserQuestion',
+              input: {
+                questions: [
+                  {
+                    question: 'Confirm?',
+                    header: 'Confirm',
+                    options: [
+                      { label: 'Yes', description: 'yes' },
+                      { label: 'No', description: 'no' },
+                    ],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        uuid: 'uuid-ask-session-a',
+        timestamp: new Date().toISOString(),
+      });
+      daemon.handleLines([askLine], `${projectsDir}/-proj/session-a.jsonl`);
+
+      // User responds in session B (different session)
+      const userLine = JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: 'response in session B' },
+        uuid: 'uuid-user-session-b',
+        timestamp: new Date().toISOString(),
+      });
+      daemon.handleLines([userLine], `${projectsDir}/-proj/session-b.jsonl`);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Session A's AskUserQuestion should still speak
+      const askMessages = spoken.filter(s => s.includes('Awaiting confirmation'));
+      expect(askMessages).toHaveLength(1);
+    });
+  });
+
   describe('non-relevant records', () => {
-    it('ignores user records', () => {
+    it('does not speak for user records', () => {
       createDaemon();
       const line = JSON.stringify({
         type: 'user',

--- a/packages/cc-voice-reporter/src/monitor/parser.test.ts
+++ b/packages/cc-voice-reporter/src/monitor/parser.test.ts
@@ -286,7 +286,7 @@ describe('extractMessages', () => {
     });
   });
 
-  it('returns empty array for user records', () => {
+  it('extracts user_response from user records', () => {
     const record: TranscriptRecord = {
       type: 'user',
       message: {
@@ -303,7 +303,9 @@ describe('extractMessages', () => {
       timestamp: '2026-01-01T00:00:06Z',
     };
 
-    expect(extractMessages(record)).toHaveLength(0);
+    const messages = extractMessages(record);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({ kind: 'user_response' });
   });
 
   it('returns empty array for progress records', () => {
@@ -445,7 +447,7 @@ describe('processLines', () => {
     ];
 
     const messages = processLines(lines);
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       kind: 'text',
       text: 'ファイルを確認します。',
@@ -456,6 +458,9 @@ describe('processLines', () => {
       toolName: 'Read',
       toolInput: { file_path: '/tmp/test.ts' },
       requestId: 'req_001',
+    });
+    expect(messages[2]).toEqual({
+      kind: 'user_response',
     });
   });
 
@@ -602,6 +607,9 @@ describe('processLines', () => {
         toolName: 'Glob',
         toolInput: { pattern: '.ai-agent/**/*' },
         requestId: 'req_A',
+      },
+      {
+        kind: 'user_response',
       },
       {
         kind: 'text',

--- a/packages/cc-voice-reporter/src/monitor/parser.ts
+++ b/packages/cc-voice-reporter/src/monitor/parser.ts
@@ -141,10 +141,15 @@ export interface ExtractedTurnComplete {
   durationMs: number | undefined;
 }
 
+export interface ExtractedUserResponse {
+  kind: 'user_response';
+}
+
 export type ExtractedMessage
   = | ExtractedText
     | ExtractedToolUse
-    | ExtractedTurnComplete;
+    | ExtractedTurnComplete
+    | ExtractedUserResponse;
 
 // -- Parse options --
 
@@ -224,6 +229,10 @@ export function extractMessages(record: TranscriptRecord): ExtractedMessage[] {
       return [{ kind: 'turn_complete', durationMs: record.durationMs }];
     }
     return [];
+  }
+
+  if (record.type === 'user') {
+    return [{ kind: 'user_response' }];
   }
 
   if (record.type !== 'assistant') {


### PR DESCRIPTION
## 目的

AskUserQuestion の音声案内が、ユーザーが既に回答した後に遅れて再生される問題を修正する（Issue #104）。
Summarizer フラッシュ（Ollama API 呼び出し）の非同期待ち中にユーザーが回答してしまうと、フラッシュ完了後に古い確認音声が再生され、混乱を招いていた。
併せて turnComplete（入力待ち案内）の通知キャンセルも同じ boolean フラグ方式に統一した。

## 変更概要

- **parser.ts**: `user` レコードから `ExtractedUserResponse`（`kind: 'user_response'`）を抽出するように変更
- **daemon.ts**:
  - `askQuestionCancelled` / `turnCompleteCancelled`（`Map<string, boolean>`）をセッション毎に管理
  - `handleLines` で `user_response` / `text` / `tool_use` メッセージ受信時にフラグを `true`（キャンセル）に設定
  - `handleAskUserQuestion` / `handleTurnComplete` でフラグを `false` にリセットし、非同期フラッシュ後にチェックしてキャンセルされていればスキップ
  - 旧 `turnCompleteGeneration` カウンター方式を boolean フラグ方式に簡素化
- **テスト追加**: Summarizer フラッシュ中のユーザー回答によるキャンセル、セッション分離のテスト等

Closes #104